### PR TITLE
Fix laggy comms on Windows when Bluetooth COM ports are enabled.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,7 @@ setup(
         "tabulate",
         "intelhex",
         "prompt_toolkit<2.1.0",
-        "pyserial",
+        "pyserial==3.3",
         "hidapi",
     ],
     data_files=[("/binho/assets", [])],


### PR DESCRIPTION
Forcing pySerial to use version 3.3 -- despite it being a few years old, there's an issue in the current releases with Bluetooth ports on windows